### PR TITLE
Community health files: Code of Conduct, Contributing, Security

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+<!-- Inherited from https://celoecosystem.com/community/community-code-of-conduct. -->
+
+# Celo Community Code of Conduct
+
+### 1. Purpose
+The Celo Code of Conduct is one of the ways we bring our value of connectedness into practice. A primary goal of the Celo community is to be welcoming and inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible.
+
+As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We invite all those who participate in the Celo community to help us create safe and positive experiences for everyone.
+
+### 2. Open Source Citizenship
+A supplemental goal of this Code of Conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between our own actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+### 3. Scope
+We expect all community participants (users; validators; contributors–paid or otherwise; sponsors; cLabs employees; and others) to abide by this Code of Conduct in all community undertakings and venues–online and in-person–as well as in all one-on-one communications pertaining to community business.
+
+This Code of Conduct and its related procedures also apply to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
+
+### 4. Expected Behavior
+The following behaviors are expected and requested of all community members:
+Exercise consideration and respect in your speech and actions. Use welcoming and inclusive language.
+Attempt collaboration before conflict.
+Refrain from demeaning, discriminatory, critical, or harassing behavior and speech.
+Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+### 5. Unacceptable Behavior
+The following behaviors are considered harassment and are unacceptable within the Celo community. Please note that this is not a comprehensive list, and in general, anything which could reasonably be considered inappropriate in a professional setting is unacceptable.
+
+* Violence, threats of violence, or violent language directed against another person.
+* Hurtful or harmful language related to:
+
+  * Background
+  * Family status
+  * Gender
+  * Gender identity or expression
+  * Marital status
+  * Sex
+  * Sexual orientation
+  * Native language
+  * Age
+  * Ability
+  * Race and/or ethnicity
+  * Caste
+  * National origin
+  * Socioeconomic status
+  * Religion
+  * Geographic location
+  * Other attributes
+
+* Posting or displaying sexually explicit or violent material.
+* Deceptive, fraudulent, or otherwise misleading communications or actions, including attempts to manipulate the price of any digital assets.
+* Posting or threatening to post other people’s personally identifying information ("doxing").
+* Personal insults, including but not limited to those related to gender, sexual orientation, race, religion, or disability.
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Sexual attention, including sexualized comments or jokes or emojis; inappropriate touching, groping, and unwelcome sexual advances.
+* Unhelpfully criticizing, flaming, or trolling members or community initiatives.
+* Deliberate intimidation, stalking, or following (online or in-person).
+* Sustained disruption of community events, including talks and presentations.
+* Advocating for, or encouraging, any of the above behavior.
+
+### 6. Consequences of Unacceptable Behavior
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. Violation of this Code of Conduct can result in you being asked to leave an event or online space, either temporarily or for the duration of the event (without refund in the case of a paid event), or being banned from participation in spaces, or future events and activities in perpetuity.
+
+Celo community members are held accountable, in addition to these guidelines, to their respective employment Anti-Harassment/Discrimination Policies. Where applicable, any such staff in violation of this Code of Conduct may be subject to further consequences, such as disciplinary action, up to and including termination of employment. For Celo community contractors or vendors, violation of this Code of Conduct could affect the continuation or renewal of a contract.
+### 7. License and attribution
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/3.0/). Portions of text derived from the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md ), the [Django Code of Conduct](https://www.djangoproject.com/conduct/), the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Community_anti-harassment), the [Mozilla Foundation](https://www.mozilla.org/en-US/about/governance/policies/participation/#note-1), and the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+
+### 8. Modifications
+
+The Celo Foundation may amend this Code of Conduct from time to time and may also vary the procedures it sets out where appropriate in a particular case. Your agreement to comply with the guidelines will be deemed agreement to any changes to it.
+
+*Last updated on the 9th of July 2021*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+<!-- Inherited from https://github.com/celo-org/celo-monorepo/blob/master/.github/CONTRIBUTING.md -->
+
+# Contributing
+
+Thank you for considering making a contribution to the Celo community!
+Everyone is encouraged to contribute, even the smallest fixes are welcome.
+
+If you'd like to contribute to Celo, please fork, fix, commit and send a
+pull request for the maintainers to review.
+
+If you wish to submit more complex changes, please sync with a core developer first.
+This will help ensure those changes are in line with the general philosophy of the project
+and enable you to get some early feedback.
+
+See the [contributing guide](https://docs.celo.org/community/contributing) for details on how to participate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,3 @@ If you wish to submit more complex changes, please sync with a core developer fi
 This will help ensure those changes are in line with the general philosophy of the project
 and enable you to get some early feedback.
 
-See the [contributing guide](https://docs.celo.org/community/contributing) for details on how to participate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,87 @@
+<!-- Inherited from https://github.com/celo-org/celo-monorepo/blob/master/SECURITY.md & https://github.com/celo-org/social-connect/blob/main/SECURITY.md -->
+
+# Security
+
+## Security Announcements
+
+> [!IMPORTANT]
+> Public announcements of new releases with security fixes and of disclosure of any vulnerabilities will be made in the Celo Forum's [Security Announcements](https://forum.celo.org/c/security-announcements/) channel.
+
+# Reporting a Vulnerability
+
+ We’re extremely grateful for security researchers and users that report vulnerabilities to the Celo community. All reports are thoroughly investigated.
+
+> [!CAUTION]
+> **Please do not create a public ticket** mentioning any vulnerability.
+
+The Celo community asks that all suspected vulnerabilities be privately and responsibly disclosed.
+
+## Creating a Report
+
+1. Submit your vulnerability to [Celo on Intigriti](https://app.intigriti.com/programs/clabs/clabs/detail). This is currently a public program
+2. You can also email the [security@clabs.co](mailto:security@clabs.co) list with the details for reproducing the vulnerability as well as the usual details expected for all bug reports.
+
+   You may encrypt your email using this GPG key, but encryption is NOT required:
+   ```
+   PGP Fingerprint ID: A22B62A5EAFB6948
+   ```
+
+## Primary Focus 
+
+- Celo protocol
+
+However, the team may be able to assist in coordinating a response to a vulnerability in the third-party apps or tools in the Celo ecosystem.
+
+# In Scope 
+
+ - https://celo.org                            
+ - https://\*.celo.org                          
+ - https://\*.clabs.co                          
+ - https://github.com/celo-org/*               
+
+# Out of Scope
+
+- Verbose messages/files/directory listings without disclosing any sensitive information                         
+- CORS misconfiguration on non-sensitive endpoints                                                               
+- Missing cookie flags                                                                                           
+- Missing security headers                                                                                                                                          
+- Presence of autocomplete attribute on web forms                                                                
+- Bypassing rate-limits                                                  
+- Clickjacking on pages with no sensitive actions                                                               
+- Host header injection without proven business impact                                                           
+- Anything related to email spoofing, SPF, DMARC or DKIM                                                      
+- Open ports without an accompanying proof-of-concept demonstrating vulnerability
+- Open write access of documents pertain to the community                                  
+
+# General
+
+- In case that a reported vulnerability was already known to the company from their own tests, it will be flagged as a duplicate.
+- Theoretical security issues with no realistic exploit scenario(s) or attack surfaces, or issues that would require complex end user interactions to be exploited, may be excluded or be lowered in severity.
+- Spam, social engineering and physical intrusion
+- DoS/DDoS attacks or brute force attacks
+- Vulnerabilities that are limited to non-current browsers (older than 3 versions) will not be accepted.
+- Attacks requiring physical access to a victim’s computer/device, man in the middle or compromised user accounts
+- Recently discovered zero-day vulnerabilities found in in-scope assets within 14 days after the public release of a patch or mitigation may be reported, but are usually not eligible for a bounty.
+- Reports that state that software is out of date/vulnerable without a proof-of-concept
+
+# Frequently Asked Questions
+
+- ❓**What will happen if a vulnerability is reported and is known to the company from their own tests?**
+
+    It will be flagged as a duplicate
+  
+- ❓**What kind of exploits are excluded from the program or may be lowered in severity?**
+
+	- Reports that state that software is out of date/vulnerable without a proof-of-concept
+	- Theoretical security issues with no realistic exploit scenario(s) or attack surfaces
+	- Issues that would require complex end user interactions to be exploited
+	- Spam, social engineering and physical intrusion
+	- DoS/DDoS attacks or brute force attacks
+	- Vulnerabilities that are limited to non-current browsers (older than 3 versions)
+	- Attacks requiring physical access to a victim’s computer/device 
+	- Man in The Middle 
+	- Compromised User Accounts
+
+- ❓**Do you accept recently disclosed zero-day vulnerabilities?**
+
+    We need time to patch our systems just like everyone else - please give us 2 weeks before reporting 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,8 +18,8 @@ The Celo community asks that all suspected vulnerabilities be privately and resp
 
 ## Creating a Report
 
-1. Submit your vulnerability to [Celo on Intigriti](https://app.intigriti.com/programs/clabs/clabs/detail). This is currently a public program
-2. You can also email the [security@clabs.co](mailto:security@clabs.co) list with the details for reproducing the vulnerability as well as the usual details expected for all bug reports.
+1. Submit your vulnerability to [Celo on Remedy](https://r.xyz). This is currently a private program in beta. Message us for an invite.
+2. You can also email the [security.report@clabs.co](mailto:security.report@clabs.co) list with the details for reproducing the vulnerability as well as the usual details expected for all bug reports.
 
    You may encrypt your email using this GPG key, but encryption is NOT required:
    ```
@@ -38,6 +38,8 @@ However, the team may be able to assist in coordinating a response to a vulnerab
  - https://\*.celo.org                          
  - https://\*.clabs.co                          
  - https://github.com/celo-org/*               
+ - https://stcelo.xyz  
+ - https://\*.stcelo.xyz  
 
 # Out of Scope
 


### PR DESCRIPTION
Add default [GitHub community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for "Code of conduct", "Contributing" and "Security" guidelines across the entire celo-org organization. They are sourced from the latest versions added on various repositories (the source is given at the top of the file).

These files will be visible on any repository that doesn't have its own specific override, which must be located at the root, inside `.github/` or inside `docs/`.