### PR TITLE
Rename renovate-config.json5 to renovate-config.json

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -9,7 +9,7 @@
               ":gitSignOff",
               ":rebaseStalePrs"],
   "automerge": false,
-  "dependencyDashboardOSVVulnerabilitySummary": "none", // 
+  "dependencyDashboardOSVVulnerabilitySummary": "none",
   "forkProcessing": "enabled",
   "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
Revert to JSON as JSON5 is not fully equivalent for path resolution when working with org-wide defaults.

Partial undo of #3.